### PR TITLE
Fix inclusion of transitive dependencies

### DIFF
--- a/cmake/templates/pkgConfig.cmake.in
+++ b/cmake/templates/pkgConfig.cmake.in
@@ -188,6 +188,7 @@ foreach(depend ${depends})
     find_package(${@PROJECT_NAME@_dep} REQUIRED NO_MODULE ${depend_list})
   endif()
   _list_append_unique(@PROJECT_NAME@_INCLUDE_DIRS ${${@PROJECT_NAME@_dep}_INCLUDE_DIRS})
+  list(APPEND @PROJECT_NAME@_LIBRARIES ${${@PROJECT_NAME@_dep}_LIBRARIES})
   list(APPEND @PROJECT_NAME@_EXPORTED_TARGETS ${${@PROJECT_NAME@_dep}_EXPORTED_TARGETS})
 endforeach()
 


### PR DESCRIPTION
It turns I have removed a bit too much when doing patches in #1.

This patch makes sure that transitive dependencies (their imported targets) are included in the `*_LIBRARIES` variable when doing a find_package() on a catkin package.