### PR TITLE
Revert "Fix inclusion of transitive dependencies"

### DIFF
--- a/cmake/templates/pkgConfig.cmake.in
+++ b/cmake/templates/pkgConfig.cmake.in
@@ -188,7 +188,6 @@ foreach(depend ${depends})
     find_package(${@PROJECT_NAME@_dep} REQUIRED NO_MODULE ${depend_list})
   endif()
   _list_append_unique(@PROJECT_NAME@_INCLUDE_DIRS ${${@PROJECT_NAME@_dep}_INCLUDE_DIRS})
-  list(APPEND @PROJECT_NAME@_LIBRARIES ${${@PROJECT_NAME@_dep}_LIBRARIES})
   list(APPEND @PROJECT_NAME@_EXPORTED_TARGETS ${${@PROJECT_NAME@_dep}_EXPORTED_TARGETS})
 endforeach()
 


### PR DESCRIPTION
Reverts hunter-packages/catkin#2.

Really sorry, I was completely wrong in #2. It has to be reverted, because packages that depend on Boost will include `${Boost_LIBRARIES}` in the list of `IMPORTED_LINK_INTERFACE_LIBRARIES_<CONFIG>`. This for example happens in `roscpp_serializationTargets-debug.cmake` and results in absolute paths being included in the following:
```cmake
IMPORTED_LINK_INTERFACE_LIBRARIES_DEBUG "ros::cpp_common;<path_to_hunter_root>/_Base/xxxxxxx/ae20f2d/2ae0aaf/Install/lib/libboost_system-mt-d.a;<rest_of_libraries...>"
```

This will break re-locatability of any such ROS package.

Why I submitted #2 was really to fix an issue in a (dummy) package called `ros_message_runtime`, but it will need to be done some other way.
